### PR TITLE
Avoid nested chdir warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 before_install:
   - "if [[ $TRAVIS_RUBY_VERSION == 1.8.7 ]] ; then rvm rubygems latest-2.1 ; fi"
+  - "if [[ $TRAVIS_RUBY_VERSION == 1.9.3 ]] ; then gem update bundler ; fi"
 rvm:
   - jruby
   - ruby-head

--- a/lib/gem-wrappers.rb
+++ b/lib/gem-wrappers.rb
@@ -43,9 +43,11 @@ module GemWrappers
   private
 
   def self.ruby_executables
-    Dir.chdir(RbConfig::CONFIG["bindir"]) {
-      Dir["*"].select{ |file| File.executable?(file) }
-    }
+    bindir = RbConfig::CONFIG["bindir"].sub(/\/+\z/, '')
+    Dir.entries(bindir).select do |file|
+      path = "#{bindir}/#{file}"
+      !File.directory?(path) && File.executable?(path)
+    end
   end
 
 end

--- a/test/gem-wrappers/command_test.rb
+++ b/test/gem-wrappers/command_test.rb
@@ -75,7 +75,7 @@ EXPECTED
       Dir.chdir(File.dirname(@file.path)) do
         subject.options[:args] = [File.basename(@file.path)]
         subject.execute
-        @fake_installer.executables.must_equal([File.realpath(@file.path)])
+        @fake_installer.executables.must_equal([Pathname.new(@file.path).realpath])
       end
     end
   end

--- a/test/gem-wrappers/command_test.rb
+++ b/test/gem-wrappers/command_test.rb
@@ -75,7 +75,7 @@ EXPECTED
       Dir.chdir(File.dirname(@file.path)) do
         subject.options[:args] = [File.basename(@file.path)]
         subject.execute
-        @fake_installer.executables.must_equal([@file.path])
+        @fake_installer.executables.must_equal([File.realpath(@file.path)])
       end
     end
   end

--- a/test/gem-wrappers/command_test.rb
+++ b/test/gem-wrappers/command_test.rb
@@ -75,7 +75,7 @@ EXPECTED
       Dir.chdir(File.dirname(@file.path)) do
         subject.options[:args] = [File.basename(@file.path)]
         subject.execute
-        @fake_installer.executables.must_equal([Pathname.new(@file.path).realpath])
+        @fake_installer.executables.must_equal([Pathname.new(@file.path).realpath.to_s])
       end
     end
   end

--- a/test/gem-wrappers/specification_and_version_test.rb
+++ b/test/gem-wrappers/specification_and_version_test.rb
@@ -17,7 +17,7 @@ describe GemWrappers::Specification do
   end
 
   it "does not find imaginary gems" do
-    GemWrappers::Specification.find("imaginary-gem").must_equal(nil)
+    GemWrappers::Specification.find("imaginary-gem").must_be_nil
   end
 
 end


### PR DESCRIPTION
After running rvm get latest, I get a lot of warnings when running bundle install:

/Users/stefan.kaes/.rvm/gems/ruby-2.4.1-railsexpress@global/gems/gem-wrappers-1.3.1/lib/gem-wrappers.rb:46: warning: conflicting chdir during another chdir block

I tracked this down to a change in for the 1.3.1 version of this gem.

This patch fixes the problem by avoiding the use of chdir.

Also, the old code had a subtle bug: directories are usually executable to, so one should exclude them from the list of binaries.